### PR TITLE
"Information Indisponible" du style Panam

### DIFF
--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -1,17 +1,19 @@
 <template>
   <div>
-    <p>Temps d'attente indisponibles.</p>
+    <p>Information indisponible</p>
   </div>
 </template>
 
 <style scoped>
 div {
-  margin: 2rem;
-  padding: 1rem;
-  background-color: var(--station-text-color);
-  color: white;
-  font-size: 2rem;
-  height: fit-content;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--waiting-time-color);
+  font-size: min(3.5rem, 5vw);
+  font-weight: bold;
 }
 
 p {


### PR DESCRIPTION
Actuellement c'est le style de ceux du RER A qu'on peut retoruver sur ces écrans là  (ce qui n'est pas très iso pour le PANAM): 
<img width="1396" alt="image" src="https://github.com/arnoclr/panam/assets/93096590/28901c24-c271-4f67-8353-071ef3607190">
Or le style des informations du PANAM est celui-ci: 
![image](https://github.com/arnoclr/panam/assets/93096590/b8ba0cc1-2b1d-43ea-8a34-74134769a700)
