### PR TITLE
feat: Recherche des arrêts par leur nom

### DIFF
--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -1,28 +1,24 @@
 <script lang="ts" setup>
 import { ref } from "vue"
 import SearchModal from "./SearchModal.vue"
-import { Position } from "../services/Wagon"
+import { SimpleLine, SimpleStop } from "../services/Wagon"
 const lineName = ref<string>("")
-const isSearchModalOpen = ref<boolean>(false)
 const position = ref<string>("")
+const searchStopDialog = ref<InstanceType<typeof SearchModal> | null>(null)
 function fillFieldWithCurrentLocation() {
   navigator.geolocation.getCurrentPosition((p) => {
     const { latitude, longitude } = p.coords
     position.value = `${latitude}, ${longitude}`
   })
 }
-const handleSelection = (idLine: string, stopPosition: Position) => {
-  lineName.value = idLine
-  position.value = `${stopPosition.lat}, ${stopPosition.long}`
+const handleSelection = (stop: SimpleStop, line: SimpleLine | null) => {
+  lineName.value = line?.number || ""
+  position.value = `${stop.position.lat}, ${stop.position.long}`
 }
 </script>
 
 <template>
-  <SearchModal
-    :isOpen="isSearchModalOpen"
-    @selection="handleSelection"
-    @close="isSearchModalOpen = false"
-  />
+  <SearchModal @selected="handleSelection" ref="searchStopDialog" />
   <div class="forms">
     <form action="/" method="get">
       <section class="searchSection">
@@ -40,7 +36,7 @@ const handleSelection = (idLine: string, stopPosition: Position) => {
           </button>
         </label>
         <div>
-          <button type="button" @click="isSearchModalOpen = true">
+          <button type="button" @click="searchStopDialog?.openModal">
             Chercher un arrêt par le nom
           </button>
         </div>

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -1,51 +1,90 @@
 <script lang="ts" setup>
 import { ref } from "vue"
-
+import SearchModal from "./SearchModal.vue"
+import { Position } from "../services/Wagon"
+const lineName = ref<string>("")
+const isSearchModalOpen = ref<boolean>(false)
 const position = ref<string>("")
-
 function fillFieldWithCurrentLocation() {
   navigator.geolocation.getCurrentPosition((p) => {
     const { latitude, longitude } = p.coords
     position.value = `${latitude}, ${longitude}`
   })
 }
+const handleSelection = (idLine: string, stopPosition: Position) => {
+  lineName.value = idLine
+  position.value = `${stopPosition.lat}, ${stopPosition.long}`
+}
 </script>
 
 <template>
-  <form action="/" method="get">
-    <label>
-      <p>Coordonnées GPS de l'arrêt</p>
-      <input
-        type="text"
-        v-model="position"
-        name="near"
-        placeholder="48.8534, 2.3122"
-        required
-      />
-      <button type="button" @click="fillFieldWithCurrentLocation">
-        Utiliser la position actuelle
-      </button>
-    </label>
-    <label>
-      <p>Numéro de la ligne</p>
-      <input type="text" name="for" placeholder="T3b" required />
-    </label>
-    <label>
-      <p>Nom de l'arrêt de destination <small>(Facultatif)</small></p>
-      <input type="text" name="directionHint" placeholder="vincennes" />
-    </label>
-    <br />
-    <br />
-    <button>Charger</button>
-  </form>
+  <SearchModal
+    :isOpen="isSearchModalOpen"
+    @selection="handleSelection"
+    @close="isSearchModalOpen = false"
+  />
+  <div class="forms">
+    <form action="/" method="get">
+      <section class="searchSection">
+        <label>
+          <p>Coordonnées GPS de l'arrêt</p>
+          <input
+            type="text"
+            v-model="position"
+            name="near"
+            placeholder="48.8534, 2.3122"
+            required
+          />
+          <button type="button" @click="fillFieldWithCurrentLocation">
+            Position actuelle
+          </button>
+        </label>
+        <div>
+          <button type="button" @click="isSearchModalOpen = true">
+            Chercher un arrêt par le nom
+          </button>
+        </div>
+      </section>
+
+      <label>
+        <p>Numéro de la ligne</p>
+        <input
+          type="text"
+          name="for"
+          placeholder="T3b"
+          v-model="lineName"
+          required
+        />
+      </label>
+      <label>
+        <p>Nom de l'arrêt de destination <small>(Facultatif)</small></p>
+        <input type="text" name="directionHint" placeholder="vincennes" />
+      </label>
+      <br />
+      <br />
+      <button>Charger</button>
+    </form>
+  </div>
 </template>
 
 <style scoped>
-form {
+.forms {
   padding: 2rem;
 }
 
 p {
   margin-bottom: 0.5rem;
+}
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: min(0.2vw, 10px);
+}
+.searchSection {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  gap: 0.5vw;
+  align-items: flex-end;
 }
 </style>

--- a/src/components/SearchModal.vue
+++ b/src/components/SearchModal.vue
@@ -1,0 +1,162 @@
+<template>
+  <div v-if="isOpen" class="backdrop" @click.self="closeDialog">
+    <dialog open>
+      <div class="header">
+        <h1>Recherche d'arrêt</h1>
+        <button class="close-button" @click="closeDialog">Fermer</button>
+      </div>
+      <div class="search-stops">
+        <div class="search">
+          <form @submit="onSubmitSearchStops">
+            <input
+              type="text"
+              name="search"
+              placeholder="Vincennes"
+              v-model="search"
+            />
+            <button type="submit">Chercher</button>
+          </form>
+        </div>
+        <div class="results" v-if="stopsLines !== null">
+          <template v-for="stop in stopsLines.stops" :key="stop.id">
+            <Stop
+              :stop="stop"
+              :lines="stopsLines.lines.filter((line: SimpleLine) => stop.lines.includes(line.id))"
+              @selected="selectStop"
+            />
+          </template>
+        </div>
+      </div>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from "vue"
+import { Position, SimpleLine, SimpleStop, Wagon } from "../services/Wagon"
+import Stop from "./Stop.vue"
+
+const search = ref<string>("")
+const stopsLines = ref<{ stops: SimpleStop[]; lines: SimpleLine[] } | null>(
+  null
+)
+const { isOpen } = defineProps<{ isOpen: boolean }>()
+
+const emits = defineEmits<{
+  selection: [idLine: string, stopPosition: Position]
+  close: []
+}>()
+
+function selectStop(stopId: string, lineId: string) {
+  const stop = stopsLines.value?.stops.find((stop) => stop.id === stopId)
+  const lineNumber =
+    stopsLines.value?.lines.find((line) => line.id === lineId)?.number || ""
+  if (!stop || !stop.position) {
+    throw new Error("Impossible de trouver la position de l'arrêt")
+  }
+  if (lineNumber !== "" && stop.position) {
+    closeDialog()
+  }
+  emits("selection", lineNumber, stop.position)
+}
+
+function onSubmitSearchStops(event: Event) {
+  event.preventDefault()
+  searchStops()
+}
+
+async function searchStops() {
+  if (search.value.trim() === "") {
+    return
+  }
+  const response = await Wagon.searchStops(search.value.trim())
+  stopsLines.value = { ...response } // Force Vue to detect change by creating a new object
+}
+
+function closeDialog() {
+  emits("close")
+}
+
+function handleKeyDown(event: KeyboardEvent) {
+  if (event.key === "Escape") {
+    closeDialog()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", handleKeyDown)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener("keydown", handleKeyDown)
+})
+</script>
+
+<style scoped>
+dialog {
+  z-index: 1000;
+  position: fixed;
+  top: 5%;
+  width: min(80%, 700px);
+  padding: 2rem;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+}
+dialog[open] {
+  animation: slide 0.3s ease;
+}
+/* dialog not open */
+dialog:not([open]) {
+  animation: slide 0.5s ease reverse;
+}
+
+@keyframes slide {
+  0% {
+    opacity: 0;
+    scale: 0.5;
+  }
+  100% {
+    opacity: 1;
+    scale: 1;
+  }
+}
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999; /* Ensure the backdrop is behind the dialog */
+}
+.search-stops {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex-grow: 1; /* Ensures the search-stops section takes up available space */
+}
+
+.search {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  overflow-y: auto;
+  max-height: 50vh; /* Adjust this value to control the scrollable area */
+}
+</style>

--- a/src/components/SearchModal.vue
+++ b/src/components/SearchModal.vue
@@ -1,60 +1,41 @@
 <template>
-  <div v-if="isOpen" class="backdrop" @click.self="closeDialog">
-    <dialog open>
-      <div class="header">
-        <h1>Recherche d'arrêt</h1>
-        <button class="close-button" @click="closeDialog">Fermer</button>
+  <dialog id="searchStopModal" ref="searchStopModal">
+    <button class="close-button" @click="closeModal">Fermer</button>
+    <div class="header">
+      <h1 class="title">Recherche d'arrêt</h1>
+    </div>
+    <div class="search-stops">
+      <div class="search">
+        <form @submit="onSubmitSearchStops">
+          <input
+            type="text"
+            name="search"
+            placeholder="Vincennes"
+            v-model="search"
+          />
+          <button type="submit">Chercher</button>
+        </form>
       </div>
-      <div class="search-stops">
-        <div class="search">
-          <form @submit="onSubmitSearchStops">
-            <input
-              type="text"
-              name="search"
-              placeholder="Vincennes"
-              v-model="search"
-            />
-            <button type="submit">Chercher</button>
-          </form>
-        </div>
-        <div class="results" v-if="stops !== null">
-          <template v-for="stop in stops" :key="stop.id">
-            <Stop :stop="stop" @selected="selectStop" />
-          </template>
-        </div>
+      <div class="results" v-if="stops !== null">
+        <template v-for="stop in stops" :key="stop.id">
+          <Stop :stop="stop" @selected="selectStop" />
+        </template>
       </div>
-    </dialog>
-  </div>
+    </div>
+  </dialog>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from "vue"
-import { Position, SimpleStop, Wagon } from "../services/Wagon"
+import { ref } from "vue"
+import { SimpleLine, SimpleStop, Wagon } from "../services/Wagon"
 import Stop from "./Stop.vue"
 
 const search = ref<string>("")
 const stops = ref<SimpleStop[] | null>(null)
-const { isOpen } = defineProps<{ isOpen: boolean }>()
-
-const emits = defineEmits<{
-  selection: [idLine: string, stopPosition: Position]
-  close: []
+const searchStopModal = ref<HTMLDialogElement | null>(null)
+const emit = defineEmits<{
+  (e: "selected", stop: SimpleStop, line: SimpleLine | null): void
 }>()
-
-function selectStop(stopId: string, lineId: string) {
-  const stop = stops.value?.find((stop) => stop.id === stopId)
-  const lineNumber =
-    stops.value
-      ?.find((stop) => stop.id === stopId)
-      ?.lines.find((line) => line.id === lineId)?.number || ""
-  if (!stop || !stop.position) {
-    throw new Error("Impossible de trouver la position de l'arrêt")
-  }
-  if (lineNumber !== "" && stop.position) {
-    closeDialog()
-  }
-  emits("selection", lineNumber, stop.position)
-}
 
 function onSubmitSearchStops(event: Event) {
   event.preventDefault()
@@ -69,35 +50,34 @@ async function searchStops() {
   stops.value = response
 }
 
-function closeDialog() {
-  emits("close")
-}
-
-function handleKeyDown(event: KeyboardEvent) {
-  if (event.key === "Escape") {
-    closeDialog()
+function selectStop(stop: SimpleStop, line: SimpleLine | null) {
+  emit("selected", stop, line)
+  if (line !== null) {
+    closeModal()
   }
 }
 
-onMounted(() => {
-  document.addEventListener("keydown", handleKeyDown)
-})
-
-onBeforeUnmount(() => {
-  document.removeEventListener("keydown", handleKeyDown)
-})
+function closeModal() {
+  searchStopModal.value?.close()
+}
+function openModal() {
+  searchStopModal.value?.showModal()
+}
+defineExpose({ openModal })
 </script>
 
 <style scoped>
-dialog {
-  z-index: 1000;
+dialog[open] {
+  margin: 0 auto;
   position: fixed;
-  top: 5%;
+  top: 10%;
+  z-index: 1000;
   width: min(80%, 700px);
   padding: 2rem;
   background: white;
   border-radius: 10px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px rgba(20, 18, 18, 0.1);
+  border: 2px rgba(27, 27, 27, 0.3) solid;
   display: flex;
   flex-direction: column;
   max-height: 80vh;
@@ -105,11 +85,6 @@ dialog {
 
 dialog[open] {
   animation: slide 0.3s ease;
-}
-
-/* dialog not open */
-dialog:not([open]) {
-  animation: slide 0.5s ease reverse;
 }
 
 @keyframes slide {
@@ -128,10 +103,10 @@ dialog:not([open]) {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
 }
 
-.backdrop {
+dialog::backdrop {
   position: fixed;
   top: 0;
   left: 0;
@@ -139,7 +114,6 @@ dialog:not([open]) {
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
   z-index: 999;
-  /* Ensure the backdrop is behind the dialog */
 }
 
 .search-stops {
@@ -147,7 +121,6 @@ dialog:not([open]) {
   flex-direction: column;
   gap: 1rem;
   flex-grow: 1;
-  /* Ensures the search-stops section takes up available space */
 }
 
 .search {
@@ -155,13 +128,18 @@ dialog:not([open]) {
   flex-direction: column;
   gap: 1rem;
 }
-
+.title {
+  font-size: min(30px, 5vw);
+}
+.close-button {
+  width: fit-content;
+  margin-left: auto;
+}
 .results {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
   overflow-y: auto;
   max-height: 50vh;
-  /* Adjust this value to control the scrollable area */
 }
 </style>

--- a/src/components/SearchModal.vue
+++ b/src/components/SearchModal.vue
@@ -17,13 +17,9 @@
             <button type="submit">Chercher</button>
           </form>
         </div>
-        <div class="results" v-if="stopsLines !== null">
-          <template v-for="stop in stopsLines.stops" :key="stop.id">
-            <Stop
-              :stop="stop"
-              :lines="stopsLines.lines.filter((line: SimpleLine) => stop.lines.includes(line.id))"
-              @selected="selectStop"
-            />
+        <div class="results" v-if="stops !== null">
+          <template v-for="stop in stops" :key="stop.id">
+            <Stop :stop="stop" @selected="selectStop" />
           </template>
         </div>
       </div>
@@ -33,13 +29,11 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount } from "vue"
-import { Position, SimpleLine, SimpleStop, Wagon } from "../services/Wagon"
+import { Position, SimpleStop, Wagon } from "../services/Wagon"
 import Stop from "./Stop.vue"
 
 const search = ref<string>("")
-const stopsLines = ref<{ stops: SimpleStop[]; lines: SimpleLine[] } | null>(
-  null
-)
+const stops = ref<SimpleStop[] | null>(null)
 const { isOpen } = defineProps<{ isOpen: boolean }>()
 
 const emits = defineEmits<{
@@ -48,9 +42,11 @@ const emits = defineEmits<{
 }>()
 
 function selectStop(stopId: string, lineId: string) {
-  const stop = stopsLines.value?.stops.find((stop) => stop.id === stopId)
+  const stop = stops.value?.find((stop) => stop.id === stopId)
   const lineNumber =
-    stopsLines.value?.lines.find((line) => line.id === lineId)?.number || ""
+    stops.value
+      ?.find((stop) => stop.id === stopId)
+      ?.lines.find((line) => line.id === lineId)?.number || ""
   if (!stop || !stop.position) {
     throw new Error("Impossible de trouver la position de l'arrêt")
   }
@@ -70,7 +66,7 @@ async function searchStops() {
     return
   }
   const response = await Wagon.searchStops(search.value.trim())
-  stopsLines.value = { ...response } // Force Vue to detect change by creating a new object
+  stops.value = response
 }
 
 function closeDialog() {
@@ -106,9 +102,11 @@ dialog {
   flex-direction: column;
   max-height: 80vh;
 }
+
 dialog[open] {
   animation: slide 0.3s ease;
 }
+
 /* dialog not open */
 dialog:not([open]) {
   animation: slide 0.5s ease reverse;
@@ -119,17 +117,20 @@ dialog:not([open]) {
     opacity: 0;
     scale: 0.5;
   }
+
   100% {
     opacity: 1;
     scale: 1;
   }
 }
+
 .header {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: flex-start;
 }
+
 .backdrop {
   position: fixed;
   top: 0;
@@ -137,13 +138,16 @@ dialog:not([open]) {
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 999; /* Ensure the backdrop is behind the dialog */
+  z-index: 999;
+  /* Ensure the backdrop is behind the dialog */
 }
+
 .search-stops {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  flex-grow: 1; /* Ensures the search-stops section takes up available space */
+  flex-grow: 1;
+  /* Ensures the search-stops section takes up available space */
 }
 
 .search {
@@ -157,6 +161,7 @@ dialog:not([open]) {
   flex-direction: column;
   gap: 0.2rem;
   overflow-y: auto;
-  max-height: 50vh; /* Adjust this value to control the scrollable area */
+  max-height: 50vh;
+  /* Adjust this value to control the scrollable area */
 }
 </style>

--- a/src/components/Stop.vue
+++ b/src/components/Stop.vue
@@ -10,7 +10,7 @@ interface StopProps {
   stop: SimpleStop
 }
 const emit = defineEmits<{
-  (e: "selected", stopId: string, lineId: string): void
+  (e: "selected", stop: SimpleStop, line: SimpleLine | null): void
 }>()
 
 const { stop } = defineProps<StopProps>()
@@ -49,7 +49,7 @@ watch(
 
 <template>
   <div class="stop">
-    <button class="stop-name" @click="$emit('selected', stop.id, '')">
+    <button class="stop-name" @click="$emit('selected', stop, null)">
       {{ stop.name }}
     </button>
     <div class="stop-lines">
@@ -62,23 +62,25 @@ watch(
               ? lines
               : lines.slice(0, MAX_DISPLAYED_LINES)"
             :key="line.id"
-            @click="$emit('selected', stop.id, line.id)"
+            @click="$emit('selected', stop, line)"
           >
             <LineIndicator
               class="line-logo"
               :line="line"
-              height="min(2vw,25px)"
+              height="min(30px, 4vw)"
             />
           </button>
-          <div v-if="lines.length > MAX_DISPLAYED_LINES" class="more-lines">
-            <button @click="toggleGroup(String(mode))">
-              {{
-                expandedGroups[mode]
-                  ? "Masquer"
-                  : `+ ${lines.length - MAX_DISPLAYED_LINES} autres lignes`
-              }}
-            </button>
-          </div>
+          <button
+            @click="toggleGroup(String(mode))"
+            v-if="lines.length > MAX_DISPLAYED_LINES"
+            class="more-lines"
+          >
+            {{
+              expandedGroups[mode]
+                ? "Masquer"
+                : `+ ${lines.length - MAX_DISPLAYED_LINES} autres lignes`
+            }}
+          </button>
         </div>
       </div>
     </div>
@@ -88,7 +90,7 @@ watch(
 <style scoped>
 .stop-name {
   color: black;
-  font-size: min(2vw, 20px);
+  font-size: min(4vw, 25px);
   margin-bottom: min(0.5vw, 5px);
 }
 .stop-name:hover {
@@ -106,7 +108,7 @@ watch(
 }
 
 .mode-icon {
-  height: min(25px, 2vw);
+  height: min(30px, 4vw);
   margin-bottom: min(0.2vw, 5px);
 }
 
@@ -126,7 +128,7 @@ button {
 }
 
 .more-lines {
-  font-size: min(1.5vw, 15px);
+  font-size: min(2vw, 15px);
   color: grey;
   align-self: center;
 }

--- a/src/components/Stop.vue
+++ b/src/components/Stop.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, defineEmits, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import { sortLines } from "../utils/Lines"
 import { SimpleLine, SimpleStop } from "../services/Wagon"
 import LineIndicator from "./LineIndicator.vue"

--- a/src/components/Stop.vue
+++ b/src/components/Stop.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { computed, ref, defineEmits, watch } from "vue"
+import { SimpleLine, SimpleStop } from "../services/Wagon"
+import LineIndicator from "./LineIndicator.vue"
+
+interface StopProps {
+  stop: SimpleStop
+  lines: SimpleLine[]
+}
+const emit = defineEmits<{
+  (e: "selected", stopId: string, lineId: string): void
+}>()
+
+const { stop, lines } = defineProps<StopProps>()
+
+function sortLines(lines: SimpleLine[]): SimpleLine[] {
+  return lines.sort((a, b) => {
+    if (!isNaN(Number(a.id)) && !isNaN(Number(b.id))) {
+      return Number(a.id) - Number(b.id)
+    } else if (!isNaN(Number(a.id))) {
+      return -1
+    } else if (!isNaN(Number(b.id))) {
+      return 1
+    } else {
+      return a.id.localeCompare(b.id)
+    }
+  })
+}
+
+const groupedLines = computed(() => {
+  const groups: { [key: string]: SimpleLine[] } = {}
+  lines.forEach((line) => {
+    if (!groups[line.pictoPng]) {
+      groups[line.pictoPng] = []
+    }
+    groups[line.pictoPng].push(line)
+  })
+
+  Object.keys(groups).forEach((mode) => {
+    groups[mode] = sortLines(groups[mode])
+  })
+
+  return groups
+})
+
+const expandedGroups = ref<{ [key: string]: boolean }>({})
+
+function toggleGroup(mode: string) {
+  expandedGroups.value[mode] = !expandedGroups.value[mode]
+}
+
+watch(
+  () => lines,
+  () => {
+    // Reset expanded groups on lines change
+    expandedGroups.value = {}
+  },
+  { deep: true }
+)
+</script>
+
+<template>
+  <div class="stop">
+    <button class="stop-name" @click="$emit('selected', stop.id, '')">
+      {{ stop.name }}
+    </button>
+    <div class="stop-lines">
+      <div v-for="(lines, mode) in groupedLines" :key="mode" class="mode-group">
+        <div class="lines">
+          <img :src="String(mode)" alt="Mode icon" class="mode-icon" />
+          <button
+            class="line"
+            v-for="line in expandedGroups[mode] ? lines : lines.slice(0, 6)"
+            :key="line.id"
+            @click="$emit('selected', stop.id, line.id)"
+          >
+            <LineIndicator class="line-logo" :line="line" height="2vw" />
+          </button>
+          <div v-if="lines.length > 6" class="more-lines">
+            <button @click="toggleGroup(String(mode))">
+              {{
+                expandedGroups[mode]
+                  ? "Masquer"
+                  : `+ ${lines.length - 6} autres lignes`
+              }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.stop-name {
+  color: black;
+  font-size: min(2vw, 20px);
+  margin-bottom: min(0.5vw, 5px);
+}
+.stop-name:hover {
+  text-decoration: none;
+}
+.stop-lines {
+  display: flex;
+  flex-direction: column;
+  gap: min(0.5vw, 10px);
+}
+
+.mode-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.mode-icon {
+  height: max(10px, 2vw);
+  margin-bottom: min(0.2vw, 5px);
+}
+
+.lines {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: min(0.2vw, 5px);
+  align-items: center;
+}
+button {
+  margin: 0;
+  padding: 0;
+}
+.line {
+  text-decoration: none;
+}
+
+.more-lines {
+  font-size: min(1.5vw, 15px);
+  color: grey;
+  align-self: center;
+}
+
+button {
+  background: none;
+  border: none;
+  color: grey;
+  cursor: pointer;
+  font-size: min(1.5vw, 15px);
+  text-decoration: underline;
+}
+</style>

--- a/src/services/Wagon.ts
+++ b/src/services/Wagon.ts
@@ -38,9 +38,8 @@ const hostname = window.location.hostname
 
 export class Wagon {
   private static BASE_URL = "https://api-wagon.arno.cl/gantry/"
-  private static LOCAL_BASE_URL = "http://localhost:8787/gantry/"
 
-private static get baseUrl(): string {
+  private static get baseUrl(): string {
     return Wagon.BASE_URL
   }
 
@@ -51,7 +50,7 @@ private static get baseUrl(): string {
 
     return "pist"
   }
-  
+
   private static positionFromDTO(positionDto: any): Position {
     return {
       lat: positionDto[0],

--- a/src/services/Wagon.ts
+++ b/src/services/Wagon.ts
@@ -40,10 +40,7 @@ export class Wagon {
   private static BASE_URL = "https://api-wagon.arno.cl/gantry/"
   private static LOCAL_BASE_URL = "http://localhost:8787/gantry/"
 
-  private static get baseUrl(): string {
-    if (hostname === "localhost") {
-      return Wagon.LOCAL_BASE_URL
-    }
+private static get baseUrl(): string {
     return Wagon.BASE_URL
   }
 
@@ -52,8 +49,9 @@ export class Wagon {
       return "vite"
     }
 
-    return "vite"
+    return "pist"
   }
+  
   private static positionFromDTO(positionDto: any): Position {
     return {
       lat: positionDto[0],

--- a/src/utils/Lines.ts
+++ b/src/utils/Lines.ts
@@ -1,0 +1,15 @@
+import { SimpleLine } from "../services/Wagon"
+
+export function sortLines(lines: SimpleLine[]): SimpleLine[] {
+  return lines.sort((a, b) => {
+    if (!isNaN(Number(a.number)) && !isNaN(Number(b.number))) {
+      return Number(a.number) - Number(b.number)
+    } else if (!isNaN(Number(a.number))) {
+      return -1
+    } else if (!isNaN(Number(b.number))) {
+      return 1
+    } else {
+      return a.number.localeCompare(b.number)
+    }
+  })
+}


### PR DESCRIPTION
Pour éviter de devoir aller chercher les coordonnées GPS depuis GMaps ou autre.
Rajoute un bouton qui ouvre une modale où on peut chercher un arrêt par son nom (se basant sur l'API de Wagon !).
<img width="1396" alt="image" src="https://github.com/arnoclr/panam/assets/93096590/cd651de0-c7b4-493c-a852-c45357343725">
Résultats : (scroll bar si trop d'arrêts sont trouvés)
<img width="1396" alt="image" src="https://github.com/arnoclr/panam/assets/93096590/5d2d8b43-cd89-473e-bc46-711a5480282f">
Cliquer sur la ligne pour remplir les coordonnées de l'arrêt de la nom de la ligne sélectionné.
Pour les arrêts avec beaucoup de lignes : 
<img width="1396" alt="image" src="https://github.com/arnoclr/panam/assets/93096590/7bfc1a24-bdf9-4f5e-96f4-590be3415663">
On peut cliquer sur 'voir plus'
<img width="1396" alt="image" src="https://github.com/arnoclr/panam/assets/93096590/28bd6aae-2fa8-4613-93e5-113063a6819d">
