### PR TITLE
feat: Affichage uniquement des disruption de la ligne dans certains cas

### DIFF
--- a/src/services/Wagon.ts
+++ b/src/services/Wagon.ts
@@ -78,7 +78,9 @@ export class Wagon {
 
     const json = await response.json()
 
-    const lineDto = json.data.lines.find((x: any) => x.number.toUpperCase() === lineNumber.toUpperCase())
+    const lineDto = json.data.lines.find(
+      (x: any) => x.number.toUpperCase() === lineNumber.toUpperCase()
+    )
 
     const line = this.lineFromDTO(lineDto)
 
@@ -142,6 +144,33 @@ export class Wagon {
 
     return "info"
   }
+  /**
+   *
+   * @param disruptions - Liste des perturbations
+   * @param currentLineName - Nom de la ligne actuelle
+   * @returns boolean True si il y a une perturbation de type incident ou stoppedService sur la ligne actuelle
+   */
+  private static shouldOnlyShowDisruptionForCurrentLine(
+    disruptions: SimpleDisruption[],
+    currentLineName: string
+  ): boolean {
+    const targetTypes = ["incident", "stoppedService"]
+    // Nombre de perturbations nécessaires pour afficher UNIQUEMENT les perturbations sur la ligne actuelle
+    const numberOfDisruptionsNeeded = 3
+    // Retourne True si il y a une perturbation de type incident ou stoppedService sur la ligne actuelle
+    // Ou s'il y a plus de 3 perturbations sur la ligne actuelle
+    return (
+      disruptions.some((disruption) => {
+        return (
+          disruption.line.number === currentLineName &&
+          targetTypes.includes(disruption.type)
+        )
+      }) ||
+      disruptions.filter((disruption) => {
+        return disruption.line.number === currentLineName
+      }).length >= numberOfDisruptionsNeeded
+    )
+  }
 
   public static async getDisruptions(
     lat: number,
@@ -187,7 +216,16 @@ export class Wagon {
         type: this.getDisruptionType(disruption.cause, disruption.effect),
       })
     }
-
+    const urlSearchParams = new URLSearchParams(window.location.search)
+    const currentLineName = urlSearchParams.get("for")
+    if (
+      currentLineName &&
+      this.shouldOnlyShowDisruptionForCurrentLine(disruptions, currentLineName)
+    ) {
+      return disruptions.filter(
+        (disruption) => disruption.line.number === currentLineName
+      )
+    }
     return disruptions
   }
 }


### PR DESCRIPTION
IRL les Infos trafic de la ligne actuelle sont prioritaires dans certains cas.
Ici s'il y en a plus de 2 ou s'il on en a de type 'incident' ou 'stoppedService' alors on affiche que celles-la.
Exemples : 
![image](https://github.com/arnoclr/panam/assets/93096590/bbb3fe26-735c-4a55-9097-55692780213d)
Incident mais on voit les infos de toutes les lignes sauf de la A
![image](https://github.com/arnoclr/panam/assets/93096590/5a0724db-eef8-41ec-ba71-d7ac9dfba360)
Après : 
![image](https://github.com/arnoclr/panam/assets/93096590/90f71301-abba-4727-bfc7-a2080ff9af6c)

