### PR TITLE
Meilleures formes pour les BUS et les Trams et fix centrage sur Métro

### DIFF
--- a/src/components/LineIndicator.vue
+++ b/src/components/LineIndicator.vue
@@ -41,10 +41,12 @@ defineProps<{
 .squareFilled,
 .rectangleFilled,
 .horizontalLines {
-  display: grid;
-  place-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   height: var(--height);
 }
+
 .circleFilled,
 .squareFilled,
 .rectangleFilled {
@@ -58,29 +60,30 @@ defineProps<{
 }
 
 .rectangleFilled {
-  padding: 0 1.5em;
+  box-sizing: border-box;
+  min-width: var(--height);
+  padding: calc(var(--height) * 0.14) calc(var(--height) * 0.2);
 }
 
 .circleFilled {
   border-radius: 50%;
 }
 
-.squareFilled,
-.rectangleFilled {
+.squareFilled {
   border-radius: calc(var(--height) * 0.2);
 }
 
+.rectangleFilled span {
+  font-size: calc(var(--height) * 0.85);
+}
 span {
   font-size: calc(var(--height) * 0.7);
   font-weight: bold;
 }
 
-.circleFilled span {
-  letter-spacing: -0.05em;
-}
-
 .horizontalLines {
   position: relative;
+  width: var(--height);
 }
 
 .horizontalLines::before,

--- a/src/components/LineIndicator.vue
+++ b/src/components/LineIndicator.vue
@@ -83,7 +83,7 @@ span {
 
 .horizontalLines {
   position: relative;
-  width: var(--height);
+  min-width: var(--height);
 }
 
 .horizontalLines::before,


### PR DESCRIPTION
Target for Issue #2
- Forme des lignes de bus plus ISO,
- Fix du offset sur les logos du métro,
- Meilleure largeur pour les lignes de TRAM
![image](https://github.com/arnoclr/panam/assets/93096590/c22df902-fe93-40b7-8eb1-8041c65230bf)
![image](https://github.com/arnoclr/panam/assets/93096590/665713a8-52ea-4cc8-81c0-7621b9ed4357)
![image](https://github.com/arnoclr/panam/assets/93096590/c8220787-f078-405e-a0e2-e5087c9a98ca)

